### PR TITLE
v2.2.1 Difficulty Algo Upgrade

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -80,13 +80,13 @@ public:
         consensus.nPowTargetTimespan =  9 * 60;  // 9 minutes - ONLY used for legacy difficulty adjustment 
         consensus.nPowTargetSpacing = 3 * 60;    // 3 minutes - target time per block 
         consensus.nDifficultyChangeActivationHeight = 21000; // Activate new difficulty rules at block 21000
-        consensus.nPerBlockDifficultyActivationHeight = 54000; // Activate per-block difficulty adjustment at block 54000
+        consensus.nPerBlockDifficultyActivationHeight = 51400; // Activate per-block difficulty adjustment at block 51400
         // Per-block difficulty adjustment parameters 
-        consensus.nPerBlockDifficultyMaxIncrease = 110; // 10% max increase
-        consensus.nPerBlockDifficultyMaxDecrease = 120; // 20% max decrease
+        consensus.nPerBlockDifficultyMaxIncrease = 105; // 5% max increase
+        consensus.nPerBlockDifficultyMaxDecrease = 110; // 10% max decrease
         consensus.fPowAllowMinDifficultyBlocks = false;
         consensus.fPowNoRetargeting = false;
-        consensus.nRuleChangeActivationThreshold = 2; // 75% of 3
+        consensus.nRuleChangeActivationThreshold = 2; 
         consensus.nMinerConfirmationWindow = 12; // nPowTargetTimespan / nPowTargetSpacing * 4
 
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
@@ -133,8 +133,8 @@ public:
         // service bits we want, but we should get them updated to support all service bits wanted by any
         // release ASAP to avoid it where possible.
         
-        vSeeds.emplace_back("seed.dns.aegisum-seeder.com");
-        vSeeds.emplace_back("dns.aegisum-seeder.com");
+        vSeeds.emplace_back("seed.aegisum.com");
+        vSeeds.emplace_back("node.aegisum.com");
 
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,24);
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,5);
@@ -188,11 +188,11 @@ public:
         consensus.MinBIP9WarningHeight = 0; // segwit activation height + miner confirmation window
         consensus.powLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         // Proof of work timing parameters
-        consensus.nPowTargetTimespan =  9 * 60;  // 9 minutes - ONLY used for legacy difficulty adjustment (pre-softfork)
+        consensus.nPowTargetTimespan =  9 * 60;  // 9 minutes - ONLY used for legacy difficulty adjustment
         consensus.nPowTargetSpacing = 3 * 60;    // 3 minutes - target time per block (used for both legacy and per-block algorithms)
-        consensus.nDifficultyChangeActivationHeight = 12; // Activate new difficulty rules at block 20000
-        consensus.nPerBlockDifficultyActivationHeight = 18; // Activate per-block difficulty adjustment at block 25
-        // Per-block difficulty adjustment parameters (Aegisum Softfork)
+        consensus.nDifficultyChangeActivationHeight = 12; // Activate new difficulty rules at block 12
+        consensus.nPerBlockDifficultyActivationHeight = 18; // Activate per-block difficulty adjustment at block 18
+        // Per-block difficulty adjustment parameters 
         consensus.nPerBlockDifficultyMaxIncrease = 110; // 10% max increase  
         consensus.nPerBlockDifficultyMaxDecrease = 120; // 20% max decrease
         consensus.fPowAllowMinDifficultyBlocks = false;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -132,7 +132,9 @@ public:
         // This is fine at runtime as we'll fall back to using them as an addrfetch if they don't support the
         // service bits we want, but we should get them updated to support all service bits wanted by any
         // release ASAP to avoid it where possible.
-        vSeeds.emplace_back("node.aegisum.com");
+        
+        vSeeds.emplace_back("seed.dns.aegisum-seeder.com");
+        vSeeds.emplace_back("dns.aegisum-seeder.com");
 
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,24);
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,5);

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -76,10 +76,14 @@ public:
         consensus.SegwitHeight = 0; 
         consensus.MinBIP9WarningHeight = 0; // segwit activation height + miner confirmation window
         consensus.powLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
-        consensus.nPowTargetTimespan =  9 * 60;
-        consensus.nPowTargetSpacing = 3 * 60;
+        // Proof of work timing parameters
+        consensus.nPowTargetTimespan =  9 * 60;  // 9 minutes - ONLY used for legacy difficulty adjustment 
+        consensus.nPowTargetSpacing = 3 * 60;    // 3 minutes - target time per block 
         consensus.nDifficultyChangeActivationHeight = 21000; // Activate new difficulty rules at block 21000
         consensus.nPerBlockDifficultyActivationHeight = 54000; // Activate per-block difficulty adjustment at block 54000
+        // Per-block difficulty adjustment parameters 
+        consensus.nPerBlockDifficultyMaxIncrease = 110; // 10% max increase
+        consensus.nPerBlockDifficultyMaxDecrease = 120; // 20% max decrease
         consensus.fPowAllowMinDifficultyBlocks = false;
         consensus.fPowNoRetargeting = false;
         consensus.nRuleChangeActivationThreshold = 2; // 75% of 3
@@ -177,18 +181,22 @@ public:
         consensus.BIP34Hash = uint256();
         consensus.BIP65Height = 76; 
         consensus.BIP66Height = 76; 
-        consensus.CSVHeight = 6048; // 00000000025e930139bac5c6c31a403776da130831ab85be56578f3fa75369bb
-        consensus.SegwitHeight = 6048; // 00000000002b980fcd729daaa248fd9316a5200e9b367f4ff2c42453e84201ca
-        consensus.MinBIP9WarningHeight = 8064; // segwit activation height + miner confirmation window
+        consensus.CSVHeight = 0; // 00000000025e930139bac5c6c31a403776da130831ab85be56578f3fa75369bb
+        consensus.SegwitHeight = 0; // 00000000002b980fcd729daaa248fd9316a5200e9b367f4ff2c42453e84201ca
+        consensus.MinBIP9WarningHeight = 0; // segwit activation height + miner confirmation window
         consensus.powLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
-        consensus.nPowTargetTimespan =  9 * 60;
-        consensus.nPowTargetSpacing = 3 * 60;
-        consensus.nDifficultyChangeActivationHeight = 20000; // Activate new difficulty rules at block 20000
-        consensus.nPerBlockDifficultyActivationHeight = 25; // Activate per-block difficulty adjustment at block 25
-        consensus.fPowAllowMinDifficultyBlocks = true;
+        // Proof of work timing parameters
+        consensus.nPowTargetTimespan =  9 * 60;  // 9 minutes - ONLY used for legacy difficulty adjustment (pre-softfork)
+        consensus.nPowTargetSpacing = 3 * 60;    // 3 minutes - target time per block (used for both legacy and per-block algorithms)
+        consensus.nDifficultyChangeActivationHeight = 12; // Activate new difficulty rules at block 20000
+        consensus.nPerBlockDifficultyActivationHeight = 18; // Activate per-block difficulty adjustment at block 25
+        // Per-block difficulty adjustment parameters (Aegisum Softfork)
+        consensus.nPerBlockDifficultyMaxIncrease = 110; // 10% max increase  
+        consensus.nPerBlockDifficultyMaxDecrease = 120; // 20% max decrease
+        consensus.fPowAllowMinDifficultyBlocks = false;
         consensus.fPowNoRetargeting = false;
         consensus.nRuleChangeActivationThreshold = 1512; // 75% for testchains
-        consensus.nMinerConfirmationWindow = 2016; // nPowTargetTimespan / nPowTargetSpacing
+        consensus.nMinerConfirmationWindow = 12; // nPowTargetTimespan / nPowTargetSpacing
 
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = Consensus::BIP9Deployment::NEVER_ACTIVE;
@@ -211,8 +219,8 @@ public:
         pchMessageStart[1] = 0xcd;
         pchMessageStart[2] = 0x83;
         pchMessageStart[3] = 0xdc;
-        nDefaultPort = 32276;
-        nPruneAfterHeight = 1000;
+        nDefaultPort = 38841;
+        nPruneAfterHeight = 100000;
         m_assumed_blockchain_size = 4;
         m_assumed_chain_state_size = 1;
 
@@ -224,9 +232,9 @@ public:
         vFixedSeeds.clear();
         vSeeds.clear();
 
-        base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,1);
-        base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,196);
-        base58Prefixes[SCRIPT_ADDRESS2] = std::vector<unsigned char>(1,0);
+        base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1, 30); // 'T'
+        base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1, 5);  // '3'
+        base58Prefixes[SCRIPT_ADDRESS2] = std::vector<unsigned char>(1, 5); // '3'
         base58Prefixes[SECRET_KEY] =     std::vector<unsigned char>(1,128);
         base58Prefixes[EXT_PUBLIC_KEY] = {0x04, 0x35, 0x87, 0xCF};
         base58Prefixes[EXT_SECRET_KEY] = {0x04, 0x35, 0x83, 0x94};
@@ -273,10 +281,14 @@ public:
         consensus.SegwitHeight = 0; // SEGWIT is always activated on regtest unless overridden
         consensus.MinBIP9WarningHeight = 0;
         consensus.powLimit = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
-        consensus.nPowTargetTimespan =  9 * 60;
-        consensus.nPowTargetSpacing = 3 * 60;
+        // Proof of work timing parameters
+        consensus.nPowTargetTimespan =  9 * 60;  // 9 minutes - ONLY used for legacy difficulty adjustment (pre-softfork)
+        consensus.nPowTargetSpacing = 3 * 60;    // 3 minutes - target time per block (used for both legacy and per-block algorithms)
         consensus.nDifficultyChangeActivationHeight = 20000; // Activate new difficulty rules at block 20000
         consensus.nPerBlockDifficultyActivationHeight = 100; // Activate per-block difficulty adjustment at block 100 for regtest
+        // Per-block difficulty adjustment parameters (Aegisum Softfork)
+        consensus.nPerBlockDifficultyMaxIncrease = 110; // 10% max increase
+        consensus.nPerBlockDifficultyMaxDecrease = 120; // 20% max decrease
         consensus.fPowAllowMinDifficultyBlocks = true;
         consensus.fPowNoRetargeting = true;
         consensus.nRuleChangeActivationThreshold = 108; // 75% for testchains

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -79,6 +79,7 @@ public:
         consensus.nPowTargetTimespan =  9 * 60;
         consensus.nPowTargetSpacing = 3 * 60;
         consensus.nDifficultyChangeActivationHeight = 21000; // Activate new difficulty rules at block 21000
+        consensus.nPerBlockDifficultyActivationHeight = 54000; // Activate per-block difficulty adjustment at block 54000
         consensus.fPowAllowMinDifficultyBlocks = false;
         consensus.fPowNoRetargeting = false;
         consensus.nRuleChangeActivationThreshold = 2; // 75% of 3
@@ -183,6 +184,7 @@ public:
         consensus.nPowTargetTimespan =  9 * 60;
         consensus.nPowTargetSpacing = 3 * 60;
         consensus.nDifficultyChangeActivationHeight = 20000; // Activate new difficulty rules at block 20000
+        consensus.nPerBlockDifficultyActivationHeight = 25; // Activate per-block difficulty adjustment at block 25
         consensus.fPowAllowMinDifficultyBlocks = true;
         consensus.fPowNoRetargeting = false;
         consensus.nRuleChangeActivationThreshold = 1512; // 75% for testchains
@@ -274,6 +276,7 @@ public:
         consensus.nPowTargetTimespan =  9 * 60;
         consensus.nPowTargetSpacing = 3 * 60;
         consensus.nDifficultyChangeActivationHeight = 20000; // Activate new difficulty rules at block 20000
+        consensus.nPerBlockDifficultyActivationHeight = 100; // Activate per-block difficulty adjustment at block 100 for regtest
         consensus.fPowAllowMinDifficultyBlocks = true;
         consensus.fPowNoRetargeting = true;
         consensus.nRuleChangeActivationThreshold = 108; // 75% for testchains

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -46,7 +46,7 @@ std::unique_ptr<CBaseChainParams> CreateBaseChainParams(const std::string& chain
     if (chain == CBaseChainParams::MAIN) {
         return MakeUnique<CBaseChainParams>("", 39940, 39941);
     } else if (chain == CBaseChainParams::TESTNET) {
-        return MakeUnique<CBaseChainParams>("testnet4", 49940, 49941);
+        return MakeUnique<CBaseChainParams>("testnet4", 38840, 38841);
     } else if (chain == CBaseChainParams::SIGNET) {
         return MakeUnique<CBaseChainParams>("signet", 322275, 39335);
     } else if (chain == CBaseChainParams::REGTEST) {

--- a/src/clientversion.cpp
+++ b/src/clientversion.cpp
@@ -28,7 +28,7 @@ const std::string CLIENT_NAME("AegisumCore");
     #define BUILD_DESC BUILD_GIT_TAG
     #define BUILD_SUFFIX ""
 #else
-    #define BUILD_DESC "v2.1.6"
+    #define BUILD_DESC "v2.2.1"
     #ifdef BUILD_GIT_COMMIT
         #define BUILD_SUFFIX "-" BUILD_GIT_COMMIT
     #elif defined(GIT_COMMIT_ID)

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -91,8 +91,11 @@ struct Params {
     int64_t DifficultyAdjustmentInterval() const { return nPowTargetTimespan / nPowTargetSpacing; }
     // Block height at which the new difficulty adjustment rules become active
     int nDifficultyChangeActivationHeight;
-    // Block height at which per-block difficulty adjustment becomes active
+    // Block height at which per-block difficulty adjustment becomes active 
     int nPerBlockDifficultyActivationHeight;
+    // Per-block difficulty adjustment parameters 
+    uint32_t nPerBlockDifficultyMaxIncrease;
+    uint32_t nPerBlockDifficultyMaxDecrease;
     /** The best chain should have at least this much work */
     uint256 nMinimumChainWork;
     /** By default assume that the signatures in ancestors of this block are valid */

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -91,6 +91,8 @@ struct Params {
     int64_t DifficultyAdjustmentInterval() const { return nPowTargetTimespan / nPowTargetSpacing; }
     // Block height at which the new difficulty adjustment rules become active
     int nDifficultyChangeActivationHeight;
+    // Block height at which per-block difficulty adjustment becomes active
+    int nPerBlockDifficultyActivationHeight;
     /** The best chain should have at least this much work */
     uint256 nMinimumChainWork;
     /** By default assume that the signatures in ancestors of this block are valid */

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -15,6 +15,15 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
     assert(pindexLast != nullptr);
     unsigned int nProofOfWorkLimit = UintToArith256(params.powLimit).GetCompact();
 
+    // Check if we're at or past the per-block difficulty activation height
+    bool fPerBlockDifficulty = (pindexLast->nHeight + 1) >= params.nPerBlockDifficultyActivationHeight;
+    
+    if (fPerBlockDifficulty) {
+        // New per-block difficulty adjustment algorithm
+        return GetNextWorkRequiredPerBlock(pindexLast, pblock, params);
+    }
+
+    // Legacy difficulty adjustment logic (pre-softfork)
     // Only change once per difficulty adjustment interval
     if ((pindexLast->nHeight+1) % params.DifficultyAdjustmentInterval() != 0)
     {
@@ -52,6 +61,65 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
     assert(pindexFirst);
 
     return CalculateNextWorkRequired(pindexLast, pindexFirst->GetBlockTime(), params);
+}
+
+unsigned int GetNextWorkRequiredPerBlock(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params& params)
+{
+    assert(pindexLast != nullptr);
+    unsigned int nProofOfWorkLimit = UintToArith256(params.powLimit).GetCompact();
+
+    // Genesis block or first block after activation
+    if (pindexLast->pprev == nullptr || pindexLast->nHeight + 1 == params.nPerBlockDifficultyActivationHeight) {
+        return pindexLast->nBits;
+    }
+
+    // Special difficulty rule for testnet:
+    // If the new block's timestamp is more than 2 * target spacing
+    // then allow mining of a min-difficulty block.
+    if (params.fPowAllowMinDifficultyBlocks) {
+        if (pblock->GetBlockTime() > pindexLast->GetBlockTime() + params.nPowTargetSpacing * 2)
+            return nProofOfWorkLimit;
+    }
+
+    // Calculate the time difference between the last block and the previous block
+    int64_t nActualTimespan = pindexLast->GetBlockTime() - pindexLast->pprev->GetBlockTime();
+    
+    // Prevent negative time (should not happen in practice, but safety first)
+    if (nActualTimespan < 0) {
+        nActualTimespan = params.nPowTargetSpacing;
+    }
+
+    // Apply per-block difficulty adjustment limits
+    // Max 10% increase in difficulty (0.9x time = 1.111x difficulty)
+    // Max 20% decrease in difficulty (1.2x time = 0.833x difficulty)
+    int64_t nMinTimespan = (params.nPowTargetSpacing * 9) / 10;  // 90% of target = max difficulty increase
+    int64_t nMaxTimespan = (params.nPowTargetSpacing * 12) / 10; // 120% of target = max difficulty decrease
+
+    if (nActualTimespan < nMinTimespan)
+        nActualTimespan = nMinTimespan;
+    if (nActualTimespan > nMaxTimespan)
+        nActualTimespan = nMaxTimespan;
+
+    // Retarget
+    arith_uint256 bnNew;
+    arith_uint256 bnOld;
+    bnNew.SetCompact(pindexLast->nBits);
+    bnOld = bnNew;
+    
+    // Aegisum: intermediate uint256 can overflow by 1 bit
+    const arith_uint256 bnPowLimit = UintToArith256(params.powLimit);
+    bool fShift = bnNew.bits() > bnPowLimit.bits() - 1;
+    if (fShift)
+        bnNew >>= 1;
+    bnNew *= nActualTimespan;
+    bnNew /= params.nPowTargetSpacing;
+    if (fShift)
+        bnNew <<= 1;
+
+    if (bnNew > bnPowLimit)
+        bnNew = bnPowLimit;
+
+    return bnNew.GetCompact();
 }
 
 unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, int64_t nFirstBlockTime, const Consensus::Params& params)

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -81,7 +81,8 @@ unsigned int GetNextWorkRequiredPerBlock(const CBlockIndex* pindexLast, const CB
             return nProofOfWorkLimit;
     }
 
-    // Calculate the time difference between the last block and the previous block
+    // Per-block difficulty adjustment - target 3 minutes per block (nPowTargetSpacing)
+    // This replaces the old system that targeted 9 minutes for 3 blocks (nPowTargetTimespan)
     int64_t nActualTimespan = pindexLast->GetBlockTime() - pindexLast->pprev->GetBlockTime();
     
     // Prevent negative time (should not happen in practice, but safety first)
@@ -89,11 +90,10 @@ unsigned int GetNextWorkRequiredPerBlock(const CBlockIndex* pindexLast, const CB
         nActualTimespan = params.nPowTargetSpacing;
     }
 
-    // Apply per-block difficulty adjustment limits
-    // Max 10% increase in difficulty (0.9x time = 1.111x difficulty)
-    // Max 20% decrease in difficulty (1.2x time = 0.833x difficulty)
-    int64_t nMinTimespan = (params.nPowTargetSpacing * 9) / 10;  // 90% of target = max difficulty increase
-    int64_t nMaxTimespan = (params.nPowTargetSpacing * 12) / 10; // 120% of target = max difficulty decrease
+    // Apply per-block difficulty adjustment limits using configurable parameters
+    // Convert percentage to fraction (e.g., 110% = 1.1, 120% = 1.2)
+    int64_t nMinTimespan = (params.nPowTargetSpacing * 100) / params.nPerBlockDifficultyMaxIncrease;
+    int64_t nMaxTimespan = (params.nPowTargetSpacing * params.nPerBlockDifficultyMaxDecrease) / 100;
 
     if (nActualTimespan < nMinTimespan)
         nActualTimespan = nMinTimespan;

--- a/src/pow.h
+++ b/src/pow.h
@@ -15,6 +15,7 @@ class CBlockIndex;
 class uint256;
 
 unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params&);
+unsigned int GetNextWorkRequiredPerBlock(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params&);
 unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, int64_t nFirstBlockTime, const Consensus::Params&);
 
 /** Check whether a block hash satisfies the proof-of-work requirement specified by nBits */

--- a/src/qt/res/bitcoin-qt-res.rc
+++ b/src/qt/res/bitcoin-qt-res.rc
@@ -4,8 +4,8 @@ IDI_ICON2 ICON DISCARDABLE "icons/bitcoin_testnet.ico"
 #include <windows.h>             // needed for VERSIONINFO
 #include "../../clientversion.h" // holds the needed client version information
 
-#define VER_PRODUCTVERSION     2,1,6,0
-#define VER_PRODUCTVERSION_STR "2.1.6"
+#define VER_PRODUCTVERSION     2,2,1,0
+#define VER_PRODUCTVERSION_STR "2.2.1"
 #define VER_FILEVERSION        VER_PRODUCTVERSION
 #define VER_FILEVERSION_STR    VER_PRODUCTVERSION_STR
 

--- a/src/version.h
+++ b/src/version.h
@@ -9,7 +9,7 @@
  * network protocol versioning
  */
 
-static const int PROTOCOL_VERSION = 70024;
+static const int PROTOCOL_VERSION = 70025;
 
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;


### PR DESCRIPTION
MANDATORY UPGRADE:

Added new mainnet and testnet params to update the block retargetting structure again.


Changes: 

As of block 51400, we will be switching to "Per-Block Difficulty" retargetting. This means instead of the difficulty (currently) changing every 3 blocks, it will change every block! This will result in less downtime, and hopefully less / no more block stalling. The range the difficulty can swing has been changed also. The new range is +5% to -10% on each retarget. Making for smoother transitions and more consistent mining experience.  This is step one of our multi step plan to mitigate network downtime and miner abuse. We are continuing to test new changes / patches on testnet.

The testnet is publicly available at https://testnet-pool.aegisum.com if you want to see where the development is heading / what changes we are testing. 
